### PR TITLE
There is no such PowerShell command as Get-Template.  The correct nam…

### DIFF
--- a/mgmtsystem/scvmm.py
+++ b/mgmtsystem/scvmm.py
@@ -120,7 +120,7 @@ class SCVMMSystem(MgmtSystemAPIBase):
 
     def list_template(self):
         data = self.run_script(
-            "Get-Template -VMMServer $scvmm_server | convertto-xml -as String")
+            "Get-SCVMTemplate -VMMServer $scvmm_server | convertto-xml -as String")
         return etree.parse(StringIO(data)).getroot().xpath("./Object/Property[@Name='Name']/text()")
 
     def list_flavor(self):


### PR DESCRIPTION
…e is Get-SCVMTemplate.  I tested it with a new and existing name and it correctly returned when a template did or did not exist.